### PR TITLE
upload image as artifact

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,11 @@ inputs:
     description: "GITHUB Token used to tag the repo"
     required: true
 
+  upload_artifact:
+    description: "whether to upload the docker image as gh artifact"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -165,3 +170,12 @@ runs:
         push: ${{ inputs.dry_run != 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        outputs: type=docker,dest=/tmp/image.tar
+
+    - name: Upload docker image as artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ inputs.upload_artifact == 'true' }}
+      with:
+        name: image
+        path: /tmp/image.tar
+        retention-days: 2


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

no jira link

## What's New?

this change allows this action to optionally upload the built image as an artifact (even in dry-run mode), so that following steps can download it and reuse the same image for other purposes, without the need to actually push the image to artifactory or quay.

## Other info

<details>
  <summary>Click for more info</summary>

```diff
Your diff here
```
</details>
