### PR TITLE
[SITEOPS] set-output replacement

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,7 @@ runs:
         $PUSH_TO_ARTIFACTORY && json=$(echo $json | jq -cr ". += [\"${{inputs.artifactory_prefix}}/${{inputs.image_name}}\"]")
         $PUSH_TO_QUAY && json=$(echo $json | jq -cr ". += [\"${{inputs.quay_prefix}}/${{inputs.image_name}}\"]")
         names=$(echo $json | jq -r '. | join(",")')
-        echo "::set-output name=names::${names}"
+        echo "names=${names}" >> $GITHUB_OUTPUT
 
     # By default the img tag is the bumped version of the last tag
     # In some edge cases we need to append a string
@@ -146,7 +146,7 @@ runs:
       id: image_tag
       run: |
         [[ -n "${{ inputs.image_tag_string_suffix }}" ]] && _ver=${{ steps.bump_version.outputs.new_version }}-${{ inputs.image_tag_string_suffix }} || _ver=${{ steps.bump_version.outputs.new_version }}
-        echo ::set-output name=ver::${_ver}
+        echo "ver=${_ver}" >> $GITHUB_OUTPUT
 
     - name: Build container meta
       id: meta


### PR DESCRIPTION
# PR Type

set-output is being deprecated

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)


## Other info

Replacing the command
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
