### PR TITLE
DEVOPS-11091 fix(github-tag-action): bump version for issue with tag increment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -210,7 +210,7 @@ runs:
 # Bump version and create git tag
     - name: Bump container version and create new github tag
       id: bump_version
-      uses: mathieudutour/github-tag-action@v6.1
+      uses: mathieudutour/github-tag-action@v1.0
       with:
         github_token: ${{ inputs.github_token }}
         tag_prefix: container/${{ inputs.image_name }}-


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables...)
- [ ] Refactoring (no functional changes, no api changes )
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other (please specify)

[Jira Link](https://sysdig.atlassian.net/browse/DEVOPS-11091)

## What's New?

Bump github-tag-action to v1.0 to include [this fix](https://github.com/mathieudutour/github-tag-action/pull/158). Previously a plain semver tag would have been considered a valid previous one, ignoring in fact the tag_prefix it was inputted.
