### PR TITLE
feat add alternative platforms (only arm64 atm)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
       - id: check-yaml
       - id: detect-private-key
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.4.1
+    rev: 0.27.3
     hooks:
       - id: check-github-workflows
+      - id: check-dependabot
+      - id: check-github-actions

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     default: ""
     required: false
 
+  image_platforms:
+    description: "optional additional architectures -comma separated- (right now only linux/amd64 and linux/arm64 are supported)"
+    required: false
+
   external_tag:
     description: "use this provided tag instead of the having the action calculate it"
     required: false
@@ -175,9 +179,10 @@ runs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         endpoint: mycontext
+        platforms: ${{ inputs.image_platforms }}
 
 # Login to registries
     - name: Login to Artifactory
@@ -250,6 +255,15 @@ runs:
         [[ -n "${{ inputs.image_tag_string_suffix }}" ]] && _suffix="-${{ inputs.image_tag_string_suffix }}" || _suffix=""
         echo "ver=${_prefix}${{ steps.bump_version.outputs.new_version }}${_suffix}" >> $GITHUB_OUTPUT
 
+    - name: Check alternative platforms and strip amd64
+      if: ${{ inputs.build == 'true' && inputs.image_platforms != '' }}
+      shell: bash
+      id: alternative_platforms
+      run: |
+        [[ -n "${{ inputs.image_platforms }}" ]] && _altplatforms=$(echo ${{ inputs.image_platforms }} | sed 's/linux\/amd64,//') || echo "No alternative platforms specified"
+        echo "DEBUG=${_altplatforms}"
+        echo "result=${_altplatforms}" >> $GITHUB_OUTPUT
+
     - name: Build container meta
       id: meta
       uses: docker/metadata-action@v4
@@ -311,6 +325,19 @@ runs:
         push: ${{ inputs.dry_run != 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Optional build container for other platforms
+      uses: docker/build-push-action@v3
+      if: ${{ inputs.build == 'true' && steps.alternative_platforms.outputs.result != '' }}
+      continue-on-error: true
+      with:
+        context: ${{ inputs.context_path }}
+        file: ${{ inputs.context_path }}/${{ inputs.dockerfile }}
+        build-args: ${{ inputs.build_args }}
+        push: ${{ inputs.dry_run != 'true' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ steps.alternative_platforms.outputs.result }}
 
     - name: Save image to file
       uses: docker/build-push-action@v3


### PR DESCRIPTION
Right now only `arm64` is supported, for other platforms -if needed- we will need to setup qemu as well.
Set with `continue-on-error: true` to avoid failing the entire pipeline in case of build error on other platforms.