### PR TITLE
fix: Update default value for input variable `ignore_image_scan_failure`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ inputs:
   ignore_image_scan_failure:
     description: "Ignore failures on image scan"
     required: false
-    default: true
+    default: "true"
   scan_type:
     description: "The type of scan to perform"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ inputs:
   ignore_image_scan_failure:
     description: "Ignore failures on image scan"
     required: false
-    default: "true"
+    default: true
   scan_type:
     description: "The type of scan to perform"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -326,7 +326,9 @@ runs:
 
     - name: Scan image
       if: inputs.run_scanner == 'true' && inputs.build == 'true'
-      continue-on-error: ${{ inputs.ignore_image_scan_failure }}
+      env:
+        IMAGE_SCAN_CONTINUE_ON_ERROR: ${{ inputs.ignore_image_scan_failure }}
+      continue-on-error: ${{ fromJSON(env.IMAGE_SCAN_CONTINUE_ON_ERROR) }}
       uses: draios/infra-action-sysdig-scan@v0.0.6
       with:
         image-tag: ${{ steps.container.outputs.container-tag }}


### PR DESCRIPTION
Implemented the workarounds documented here
- https://github.com/aquasecurity/trivy-action/issues/417
- https://github.com/actions/runner/issues/1492